### PR TITLE
Fix global variable & implement optional "object-mode" output

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,13 @@ This module also provides a simple api that you can use in your own node project
 ```
 var Smartystreets = require('smartystreets');
 var fs = require('fs');
+var csv = require('fast-csv');
 
 var geocoder = new Smartystreets(options);
 
 fs.createReadStream('input.csv')
+  .pipe(csv({ headers: true }))
+  .pipe(Smartystreets.grouper(70))
   .pipe(geocoder)
   .pipe(process.stdout);
 ```
@@ -148,6 +151,10 @@ fs.createReadStream('input.csv')
 In this example, `geocoder` is a duplex stream which will take every address that is written to it in CSV format and output a geocoded CSV.
 
 The `options` argument is identical to the options used by the command line tool, except that camelCase is used (street-col -> streetCol) and "input" and "output" are ignored (instead use the piping solution above).
+
+For more API details, see [our TypeScript API declarations][API].
+
+[API]: https://github.com/faradayio/node_smartystreets/blob/master/index.d.ts
 
 ## Notes
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,13 +6,23 @@ export = smartystreets
  * Create a {@link NodeJS.ReadWriteStream} which consumes CSV records and
  * outputs them with geocoding information from smartystreets.
  *
+ * Input records should be objects, with keys corresponding to column names:
+ *
+ *     { street: "a", zipcode: "b" }
+ *
+ * Output record format is controlled by {@link Options.outputStreamFormat}. By
+ * default, the output will be in array format, but if `outputStreamFormat:
+ * "object"` is set, output will look like:
+ *
+ *     { street: "a", zipcode: "b", ss_field1: "...", ... }
+ *
  * @param opts
  */
 declare function smartystreets(opts?: smartystreets.Options): NodeJS.ReadWriteStream
 
 declare namespace smartystreets {
     /** Geocoding options for smartystreets. */
-    type Options = {
+    export type Options = {
         /**
          * SmartyStreets auth ID. You can get this
          * {@link here|https://smartystreets.com/account/keys} listed under
@@ -112,5 +122,25 @@ declare namespace smartystreets {
          * potentially-large precision degredation.
          */
         includeInvalid?: boolean
+        /**
+         * Should we stream the output data as objects or as arrays?  Default is
+         * `"array"`, but only for backwards compatibility. Sample array output:
+         *
+         *     ["col1", "col2"]
+         *     ["val1", "val2"]
+         *     ["val3", "val4"]
+         *
+         * Sample object output:
+         *
+         *     {"col1": "val1", "col2": "val2"}
+         *     {"col1": "val3", "col2": "val4"}
+         */
+        outputStreamFormat?: OutputStreamFormat
     }
+
+    /**
+     * Allowed `outputStreamFormat` values. We declare this as a named type
+     * so that our callers can use it in their own APIs if desired.
+     */
+    export type OutputStreamFormat = "object" | "array"
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,21 +6,44 @@ export = smartystreets
  * Create a {@link NodeJS.ReadWriteStream} which consumes CSV records and
  * outputs them with geocoding information from smartystreets.
  *
- * Input records should be objects, with keys corresponding to column names:
+ * Input records should be arrays of objects, with keys corresponding to column
+ * names. This can be done by using `smartystreets.grouper(70)` stream
+ * transformer to batch 70 records together into an array.
  *
- *     { street: "a", zipcode: "b" }
+ *     [{ street: "a", zipcode: "b" }, { street: "c", zipcode: "d"}, ...]
+ *     [{ street: "e", zipcode: "f" }, ...]
  *
  * Output record format is controlled by {@link Options.outputStreamFormat}. By
  * default, the output will be in array format, but if `outputStreamFormat:
  * "object"` is set, output will look like:
  *
  *     { street: "a", zipcode: "b", ss_field1: "...", ... }
+ *     { street: "c", zipcode: "d", ss_field1: "...", ... }
+ *     ...
  *
- * @param opts
+ * @param opts Configuration options.
  */
 declare function smartystreets(opts?: smartystreets.Options): NodeJS.ReadWriteStream
 
 declare namespace smartystreets {
+    /**
+     * Create a stream which transforms input of the form:
+     *
+     *     {a: 1}
+     *     {a: 2}
+     *     {a: 3}
+     *
+     * ...to:
+     *
+     *     [{a: 1}, {a: 2}]
+     *     [{a: 3}]
+     *
+     * ...using the specified `groupSize`.
+     *
+     * @param groupSize The number of records to put in each group.
+     */
+    export function grouper(groupSize: number): NodeJS.ReadWriteStream
+
     /** Geocoding options for smartystreets. */
     export type Options = {
         /**

--- a/index.js
+++ b/index.js
@@ -1,1 +1,2 @@
 module.exports = require('./lib/geocoder');
+module.exports.grouper = require('./lib/grouper');

--- a/lib/geocoder.js
+++ b/lib/geocoder.js
@@ -1,3 +1,4 @@
+var assert = require('assert')
 var through2 = require('through2-concurrent');
 var async = require('async');
 var request = require('request');
@@ -5,8 +6,7 @@ var querystring = require('querystring');
 
 var structuredRow = require('./structuredRow');
 
-var columnList;
-var addColumns = function (row) {
+var addColumns = function (columnList, row) {
   var out = [];
   columnList.forEach(function(column){
     out.push(row[column]);
@@ -14,8 +14,7 @@ var addColumns = function (row) {
   return out;
 };
 
-
-var geocodeChunk = function(item, queue, progress, pool, options, callback){
+var geocodeChunk = function(item, queue, columnList, progress, pool, options, callback){
   var streetColArray = Array.isArray(options.streetCol);
   var rows = item.rows;
   item.tries++;
@@ -153,8 +152,10 @@ module.exports = function(opts){
     maxSockets: 1024
   };
 
+  var columnList;
   var geocodingQueue = async.queue(function(chunk, callback){
-    geocodeChunk(chunk, geocodingQueue, progress, pool, options, callback);
+    assert.notStrictEqual(columnList, undefined)
+    geocodeChunk(chunk, geocodingQueue, columnList, progress, pool, options, callback);
   }, options.concurrency);
 
   var droppedRecords = 0;

--- a/lib/geocoder.js
+++ b/lib/geocoder.js
@@ -6,13 +6,23 @@ var querystring = require('querystring');
 
 var structuredRow = require('./structuredRow');
 
-var addColumns = function (columnList, row) {
-  var out = [];
+/** Convert a CSV record object to a record array. */
+var objectToArray = function (columnList, recordObject) {
+  var recordArray = [];
   columnList.forEach(function(column){
-    out.push(row[column]);
+    recordArray.push(recordObject[column]);
   });
-  return out;
+  return recordArray;
 };
+
+/** Convert a CSV record array to a record object. */
+var arrayToObject = function (columnList, recordArray) {
+  var recordObject = {};
+  for (var i = 0; i < columnList.length; ++i) {
+    recordObject[columnList[i]] = recordArray[i];
+  }
+  return recordObject;
+}
 
 var geocodeChunk = function(item, queue, columnList, progress, pool, options, callback){
   var streetColArray = Array.isArray(options.streetCol);
@@ -118,7 +128,7 @@ var geocodeChunk = function(item, queue, columnList, progress, pool, options, ca
         console.log(progress.total+' rows done, '+ percentGeocoded + '% geocoded, ' + perSecond+' rows per second');
       }
 
-      return addColumns(row);
+      return objectToArray(columnList, row);
     }));
 
     callback();
@@ -127,7 +137,8 @@ var geocodeChunk = function(item, queue, columnList, progress, pool, options, ca
 
 
 var defaultOptions = {
-  concurrency: 48
+  concurrency: 48,
+  outputStreamFormat: "array",
 };
 
 module.exports = function(opts){
@@ -170,7 +181,9 @@ module.exports = function(opts){
 
         var ss_columns = Object.keys(structuredRow(options.structure, {}, options.columnPrefix, options.columnSuffix));
         columnList = Object.keys(rows[0]).concat(ss_columns);
-        this.push(columnList);
+        if (options.outputStreamFormat === "array") {
+          this.push(columnList);
+        }
       }
 
       var self = this;
@@ -180,7 +193,11 @@ module.exports = function(opts){
         tries: 0,
         callback: function(doneRows){
           doneRows.forEach(function(row){
-            self.push(row);
+            if (options.outputStreamFormat === "array") {
+              self.push(row);
+            } else {
+              self.push(arrayToObject(columnList, row))
+            }
           });
           cb();
         },


### PR DESCRIPTION
**NEW APIs**, please release as 1.8.0.

Bug fixes:

- SmartyStreets contains a global variable named `columnList` that prevents it from running two different encodings in parallel. This PR fixes that global variable.

New APIs:

- SmartyStreets now accepts an `outputStreamFormat: "object"` flag which will cause it to output JavaScript objects keyed by column name. This defaults to the existing behavior (`"array"`) so as not to break callers.
- SmartyStreets now exports the `grouper` module used to group its input records, since it's hard to use without it. And the documentation has been updated to explain how to use the APIs as they exist.

This has been tested against an internal project with basic test suites.